### PR TITLE
O11Y-483: parallel coreos CRDs

### DIFF
--- a/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: alertmanagerconfigs.monitoring.coreos.com
+  name: alertmanagerconfigs.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: alertmanagers.monitoring.coreos.com
+  name: alertmanagers.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: podmonitors.monitoring.coreos.com
+  name: podmonitors.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-probes.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-probes.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: probes.monitoring.coreos.com
+  name: probes.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: prometheuses.monitoring.coreos.com
+  name: prometheuses.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: prometheusrules.monitoring.coreos.com
+  name: prometheusrules.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: servicemonitors.monitoring.coreos.com
+  name: servicemonitors.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: thanosrulers.monitoring.coreos.com
+  name: thanosrulers.v45-monitoring.coreos.com
 spec:
-  group: monitoring.coreos.com
+  group: v45-monitoring.coreos.com
   names:
     categories:
     - prometheus-operator

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.alertmanager.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: {{ template "kube-prometheus-stack.alertmanager.crname" . }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.serviceMonitor.selfMonitor }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.coreDns.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-coredns

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubeApiServer.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-apiserver

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.kubeControllerManager.enabled .Values.kubeControllerManager.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-controller-manager

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubeDns.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-dns

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.kubeEtcd.enabled .Values.kubeEtcd.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-etcd

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.kubeProxy.enabled .Values.kubeProxy.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-proxy

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.kubeScheduler.enabled .Values.kubeScheduler.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-kube-scheduler

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubelet.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-kubelet

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.serviceMonitor.selfMonitor }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml
@@ -7,7 +7,7 @@ metadata:
 items:
 {{- if .Values.additionalPrometheusRulesMap }}
 {{- range $prometheusRuleName, $prometheusRule := .Values.additionalPrometheusRulesMap }}
-  - apiVersion: monitoring.coreos.com/v1
+  - apiVersion: v45-monitoring.coreos.com/v1
     kind: PrometheusRule
     metadata:
       name: {{ template "kube-prometheus-stack.name" $ }}-{{ $prometheusRuleName }}
@@ -24,7 +24,7 @@ items:
 {{- end }}
 {{- else }}
 {{- range .Values.additionalPrometheusRules }}
-  - apiVersion: monitoring.coreos.com/v1
+  - apiVersion: v45-monitoring.coreos.com/v1
     kind: PrometheusRule
     metadata:
       name: {{ template "kube-prometheus-stack.name" $ }}-{{ .name }}

--- a/charts/kube-prometheus-stack/templates/prometheus/podmonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/podmonitors.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: List
 items:
 {{- range .Values.prometheus.additionalPodMonitors }}
-  - apiVersion: monitoring.coreos.com/v1
+  - apiVersion: v45-monitoring.coreos.com/v1
     kind: PodMonitor
     metadata:
       name: {{ .name }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.prometheus.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: {{ template "kube-prometheus-stack.prometheus.crname" . }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
@@ -7,7 +7,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
 {{- $alertmanagerJob := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "alertmanager" }}
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "alertmanager.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.configReloaders }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "config-reloaders" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeEtcd.enabled .Values.defaultRules.rules.etcd }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "etcd" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "general.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "k8s.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverAvailability }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-availability.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverBurnrate }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-burnrate.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverHistogram }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-histogram.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserverSlos }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-apiserver-slos" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusGeneral }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-prometheus-general.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeRecording }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-prometheus-node-recording.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeSchedulerRecording }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-scheduler.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubeStateMetrics }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kube-state-metrics" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubelet.enabled .Values.defaultRules.rules.kubelet }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubelet.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -6,7 +6,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesApps }}
 {{- $targetNamespace := .Values.defaultRules.appNamespacesTarget }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-apps" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-resources" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -6,7 +6,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesStorage }}
 {{- $targetNamespace := .Values.defaultRules.appNamespacesTarget }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-storage" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-apiserver" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeControllerManager.enabled .Values.defaultRules.rules.kubeControllerManager }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-controller-manager" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kube-proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kube-proxy.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeProxy.enabled .Values.defaultRules.rules.kubeProxy }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-kube-proxy" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-kubelet" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeSchedulerAlerting }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system-scheduler" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "kubernetes-system" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.nodeExporterRecording }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node-exporter.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.nodeExporterAlerting }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node-exporter" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.network }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node-network" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
@@ -5,7 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.node }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "node.rules" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
@@ -7,7 +7,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheusOperator }}
 {{- $operatorJob := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "operator" }}
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus-operator" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
@@ -7,7 +7,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheus }}
 {{- $prometheusJob := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" }}
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" | trunc 63 | trimSuffix "-" }}

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.serviceMonitor.selfMonitor }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.thanosService.enabled .Values.prometheus.thanosServiceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-sidecar

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: List
 items:
 {{- range .Values.prometheus.additionalServiceMonitors }}
-  - apiVersion: monitoring.coreos.com/v1
+  - apiVersion: v45-monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
       name: {{ .name }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.thanosRuler.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
   name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.thanosRuler.enabled .Values.thanosRuler.serviceMonitor.selfMonitor }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: v45-monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1859,7 +1859,7 @@ prometheusOperator:
     failurePolicy:
     ## The default timeoutSeconds is 10 and the maximum value is 30.
     timeoutSeconds: 10
-    enabled: true
+    enabled: false
     ## A PEM encoded CA bundle which will be used to validate the webhook's server certificate.
     ## If unspecified, system trust roots on the apiserver are used.
     caBundle: ""
@@ -1871,7 +1871,7 @@ prometheusOperator:
     #   argocd.argoproj.io/hook: PreSync
     #   argocd.argoproj.io/hook-delete-policy: HookSucceeded
     patch:
-      enabled: true
+      enabled: false
       image:
         registry: registry.k8s.io
         repository: ingress-nginx/kube-webhook-certgen


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
run parallel coreos crds in the same cluser

#### Which issue this PR fixes
running parallel helm chart of kube-prometheus-stack will help us to migrate gradually and safely in order to deprecate metrics without breaking any environment
